### PR TITLE
Add light theme with theme toggle

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,14 +1,74 @@
 :root {
-  color-scheme: light dark;
-  --bg: #10131a;
-  --bg-alt: #161b24;
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color-scheme: dark;
   --accent: #f0b429;
   --accent-dark: #c78c1b;
   --text: #f5f6f8;
   --muted: #a0acc0;
-  --error: #d9534f;
-  --success: #3cba92;
-  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg: #10131a;
+  --bg-alt: #161b24;
+  --body-gradient: radial-gradient(circle at top, rgba(240, 180, 41, 0.08), transparent 55%), var(--bg);
+  --surface: rgba(16, 19, 26, 0.65);
+  --surface-strong: rgba(16, 19, 26, 0.75);
+  --surface-soft: rgba(8, 11, 18, 0.55);
+  --surface-muted: rgba(8, 11, 18, 0.6);
+  --surface-muted-strong: rgba(8, 11, 18, 0.85);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.12);
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --header-gradient: linear-gradient(135deg, rgba(240, 180, 41, 0.2), rgba(16, 19, 26, 0.8));
+  --button-bg: rgba(255, 255, 255, 0.08);
+  --button-bg-hover: rgba(255, 255, 255, 0.15);
+  --button-secondary-bg: rgba(60, 186, 146, 0.25);
+  --focus-ring: rgba(240, 180, 41, 0.6);
+  --hero-shadow: rgba(0, 0, 0, 0.25);
+  --card-shadow: rgba(0, 0, 0, 0.2);
+  --flash-success-surface: rgba(60, 186, 146, 0.15);
+  --flash-success-border: rgba(60, 186, 146, 0.4);
+  --flash-error-surface: rgba(217, 83, 79, 0.15);
+  --flash-error-border: rgba(217, 83, 79, 0.45);
+  --footer-bg: rgba(8, 11, 18, 0.8);
+  --skill-chip-bg: rgba(240, 180, 41, 0.25);
+  --skill-chip-text: var(--accent);
+  --input-bg: rgba(8, 11, 18, 0.6);
+  --input-bg-focus: rgba(8, 11, 18, 0.85);
+  --input-border: var(--border-strong);
+  --nav-divider: rgba(255, 255, 255, 0.12);
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --bg: #f7f9ff;
+  --bg-alt: #edf2ff;
+  --body-gradient: radial-gradient(circle at top, rgba(240, 180, 41, 0.18), transparent 60%), var(--bg);
+  --text: #1b2435;
+  --muted: #62708c;
+  --surface: rgba(255, 255, 255, 0.85);
+  --surface-strong: rgba(255, 255, 255, 0.95);
+  --surface-soft: rgba(232, 238, 247, 0.75);
+  --surface-muted: rgba(255, 255, 255, 0.9);
+  --surface-muted-strong: rgba(255, 255, 255, 1);
+  --border: rgba(21, 40, 82, 0.12);
+  --border-strong: rgba(21, 40, 82, 0.2);
+  --border-subtle: rgba(21, 40, 82, 0.08);
+  --header-gradient: linear-gradient(135deg, rgba(240, 180, 41, 0.3), rgba(233, 238, 249, 0.95));
+  --button-bg: rgba(27, 36, 53, 0.08);
+  --button-bg-hover: rgba(27, 36, 53, 0.12);
+  --button-secondary-bg: rgba(60, 186, 146, 0.2);
+  --focus-ring: rgba(240, 180, 41, 0.45);
+  --hero-shadow: rgba(15, 23, 42, 0.12);
+  --card-shadow: rgba(15, 23, 42, 0.1);
+  --flash-success-surface: rgba(60, 186, 146, 0.1);
+  --flash-success-border: rgba(60, 186, 146, 0.32);
+  --flash-error-surface: rgba(217, 83, 79, 0.1);
+  --flash-error-border: rgba(217, 83, 79, 0.32);
+  --footer-bg: rgba(255, 255, 255, 0.92);
+  --skill-chip-bg: rgba(240, 180, 41, 0.18);
+  --skill-chip-text: #5c3b07;
+  --input-bg: rgba(255, 255, 255, 0.92);
+  --input-bg-focus: rgba(255, 255, 255, 1);
+  --input-border: var(--border);
+  --nav-divider: rgba(21, 40, 82, 0.16);
 }
 
 * {
@@ -18,19 +78,36 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(240, 180, 41, 0.08), transparent 55%), var(--bg);
+  background: var(--body-gradient);
+  background-color: var(--bg);
   color: var(--text);
   display: flex;
   flex-direction: column;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .site-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: clamp(1rem, 2vw, 2rem);
   padding: 1.5rem clamp(1rem, 4vw, 3rem);
-  background: linear-gradient(135deg, rgba(240, 180, 41, 0.2), rgba(16, 19, 26, 0.8));
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--header-gradient);
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .site-header .brand h1 {
@@ -43,11 +120,66 @@ body {
   color: var(--muted);
 }
 
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text);
+}
+
 .nav-user {
   display: flex;
   gap: 0.75rem;
   align-items: center;
   color: var(--text);
+}
+
+.nav-user a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--button-bg);
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background: var(--button-bg-hover);
+  transform: translateY(-1px);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.theme-toggle svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  display: block;
+}
+
+.theme-toggle .icon-sun,
+.theme-toggle .icon-moon {
+  display: none;
+}
+
+:root[data-theme='dark'] .theme-toggle .icon-moon {
+  display: block;
+}
+
+:root[data-theme='light'] .theme-toggle .icon-sun {
+  display: block;
 }
 
 .content-area {
@@ -61,11 +193,12 @@ body {
 }
 
 .hero {
-  background: rgba(16, 19, 26, 0.65);
+  background: var(--surface);
   padding: clamp(1.25rem, 3vw, 2rem);
   border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 40px var(--hero-shadow);
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
 }
 
 .hero h2 {
@@ -82,11 +215,12 @@ body {
 }
 
 .card {
-  background: rgba(16, 19, 26, 0.75);
+  background: var(--surface-strong);
   border-radius: 1rem;
   padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 30px var(--card-shadow);
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
 }
 
 .card h3 {
@@ -104,16 +238,17 @@ input {
   width: 100%;
   padding: 0.6rem 0.75rem;
   border-radius: 0.6rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--input-border);
   margin-bottom: 0.9rem;
-  background: rgba(8, 11, 18, 0.6);
+  background: var(--input-bg);
   color: var(--text);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 input:focus {
-  outline: 2px solid rgba(240, 180, 41, 0.6);
+  outline: 2px solid var(--focus-ring);
   border-color: var(--accent);
-  background: rgba(8, 11, 18, 0.85);
+  background: var(--input-bg-focus);
 }
 
 .password-strength {
@@ -123,7 +258,7 @@ input:focus {
 .password-strength-bar {
   height: 0.45rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--border);
   overflow: hidden;
   margin-bottom: 0.35rem;
 }
@@ -147,14 +282,14 @@ input:focus {
 
 .password-strength-text {
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--muted);
 }
 
 .password-match {
   font-size: 0.85rem;
   margin: -0.35rem 0 0.85rem;
   min-height: 1.1rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--muted);
 }
 
 .password-match.success {
@@ -169,7 +304,7 @@ input:focus {
   font-size: 0.85rem;
   margin: 0.35rem 0 0.85rem;
   min-height: 1.1rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--muted);
 }
 
 .availability-message:empty {
@@ -195,16 +330,16 @@ button {
   border-radius: 0.6rem;
   font-weight: 600;
   cursor: pointer;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--button-bg);
   color: var(--text);
-  transition: transform 0.15s ease, background 0.15s ease;
+  transition: transform 0.15s ease, background-color 0.15s ease, color 0.15s ease;
   text-decoration: none;
 }
 
 .button:hover,
 button:hover {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--button-bg-hover);
 }
 
 .button.primary {
@@ -217,7 +352,7 @@ button:hover {
 }
 
 .button.secondary {
-  background: rgba(60, 186, 146, 0.25);
+  background: var(--button-secondary-bg);
   color: var(--text);
 }
 
@@ -259,16 +394,17 @@ button:disabled {
   align-items: center;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
-  background: rgba(8, 11, 18, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--surface-soft);
+  border: 1px solid var(--border-subtle);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 .skill-value {
   display: inline-block;
   padding: 0.15rem 0.5rem;
   border-radius: 999px;
-  background: rgba(240, 180, 41, 0.25);
-  color: var(--accent);
+  background: var(--skill-chip-bg);
+  color: var(--skill-chip-text);
   font-size: 0.85rem;
   margin-left: 0.75rem;
 }
@@ -278,6 +414,7 @@ button:disabled {
   border-radius: 0.75rem;
   font-weight: 600;
   border: 1px solid transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .flash + .flash {
@@ -285,14 +422,14 @@ button:disabled {
 }
 
 .flash-success {
-  background: rgba(60, 186, 146, 0.15);
-  border-color: rgba(60, 186, 146, 0.4);
+  background: var(--flash-success-surface);
+  border-color: var(--flash-success-border);
   color: var(--text);
 }
 
 .flash-error {
-  background: rgba(217, 83, 79, 0.15);
-  border-color: rgba(217, 83, 79, 0.45);
+  background: var(--flash-error-surface);
+  border-color: var(--flash-error-border);
   color: var(--text);
 }
 
@@ -301,11 +438,22 @@ button:disabled {
   padding: 1.5rem;
   color: var(--muted);
   font-size: 0.9rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(8, 11, 18, 0.8);
+  border-top: 1px solid var(--border);
+  background: var(--footer-bg);
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 @media (max-width: 600px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .site-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
   .nav-user {
     flex-direction: column;
     align-items: flex-end;

--- a/src/templates.js
+++ b/src/templates.js
@@ -22,6 +22,104 @@ function layout({ title, body, user, flash }) {
       }! <form method="POST" action="/logout" class="inline-form"><button type="submit">Logi välja</button></form></div>`
     : '<div class="nav-user"><a href="/">Avaleht</a></div>';
 
+  const themeToggle = `<button type="button" class="theme-toggle" data-theme-toggle aria-label="Vaheta teemat">
+    <span class="visually-hidden" data-theme-toggle-text>Vaheta teemat</span>
+    <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true" focusable="false" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="4"></circle>
+      <path d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-7.364-1.414 1.414M7.05 16.95l-1.414 1.414M18.364 18.364l-1.414-1.414M7.05 7.05 5.636 5.636"></path>
+    </svg>
+    <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true" focusable="false" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 12.79A9 9 0 0 1 11.21 3a7 7 0 1 0 9.79 9.79Z"></path>
+    </svg>
+  </button>`;
+
+  const themeScript = `<script>
+    (function () {
+      var storageKey = 'legendidle-theme';
+      var root = document.documentElement;
+      var mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+      function getStoredTheme() {
+        try {
+          return window.localStorage.getItem(storageKey);
+        } catch (err) {
+          return null;
+        }
+      }
+
+      function setStoredTheme(theme) {
+        try {
+          window.localStorage.setItem(storageKey, theme);
+        } catch (err) {
+          // Ignore write errors
+        }
+      }
+
+      function systemTheme() {
+        return mediaQuery.matches ? 'dark' : 'light';
+      }
+
+      function applyTheme(theme) {
+        var next = theme === 'light' ? 'light' : 'dark';
+        root.dataset.theme = next;
+        root.style.colorScheme = next;
+        return next;
+      }
+
+      function updateToggle() {
+        var toggle = document.querySelector('[data-theme-toggle]');
+        if (!toggle) {
+          return;
+        }
+        var current = root.dataset.theme === 'light' ? 'light' : 'dark';
+        var next = current === 'dark' ? 'light' : 'dark';
+        var label = next === 'dark' ? 'Lülita tumedale teemale' : 'Lülita heledale teemale';
+        toggle.setAttribute('aria-label', label);
+        toggle.setAttribute('title', label);
+        var text = toggle.querySelector('[data-theme-toggle-text]');
+        if (text) {
+          text.textContent = label;
+        }
+      }
+
+      var storedTheme = getStoredTheme();
+      var initialTheme = storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : systemTheme();
+      applyTheme(initialTheme);
+      updateToggle();
+
+      function handleMediaChange(event) {
+        if (getStoredTheme()) {
+          return;
+        }
+        applyTheme(event.matches ? 'dark' : 'light');
+        updateToggle();
+      }
+
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', handleMediaChange);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(handleMediaChange);
+      }
+
+      document.addEventListener('DOMContentLoaded', function () {
+        var toggle = document.querySelector('[data-theme-toggle]');
+        if (!toggle) {
+          return;
+        }
+
+        updateToggle();
+
+        toggle.addEventListener('click', function () {
+          var current = root.dataset.theme === 'light' ? 'light' : 'dark';
+          var next = current === 'dark' ? 'light' : 'dark';
+          applyTheme(next);
+          setStoredTheme(next);
+          updateToggle();
+        });
+      });
+    })();
+  </script>`;
+
   const passwordScript = `<script>
     (function () {
       const forms = document.querySelectorAll('form[data-password-form]');
@@ -318,11 +416,12 @@ function layout({ title, body, user, flash }) {
   </script>`;
 
   return `<!DOCTYPE html>
-<html lang="et">
+<html lang="et" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${escapeHtml(title)}</title>
+  ${themeScript}
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
@@ -331,7 +430,10 @@ function layout({ title, body, user, flash }) {
       <h1>LegendIdle</h1>
       <p>RuneScape'i stiilis brauserimängu prototüüp</p>
     </div>
-    ${navLinks}
+    <div class="site-nav">
+      ${themeToggle}
+      ${navLinks}
+    </div>
   </header>
   <main class="content-area">
     ${renderFlash(flash)}


### PR DESCRIPTION
## Summary
- add a navigation theme toggle with SVG icons and initialization script that respects system preferences and stores user choices
- render the updated header structure so the toggle sits beside user navigation while defaulting the page to the dark theme
- expand the shared stylesheet with light-theme tokens, adaptive surfaces, and transitions for inputs, cards, and footer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8556a3a08332ace8a295ca40c42c