### PR TITLE
Add profile dropdown and guest registration modal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -43,11 +43,179 @@ body {
   color: var(--muted);
 }
 
-.nav-user {
+.nav-actions {
   display: flex;
   gap: 0.75rem;
   align-items: center;
+  justify-content: flex-end;
+}
+
+.nav-user {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   color: var(--text);
+}
+
+.nav-user-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.6rem;
+  padding: 0.4rem 0.85rem 0.4rem 0.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 11, 18, 0.6);
+  color: inherit;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  transform: none;
+}
+
+.nav-user-toggle:hover {
+  background: rgba(8, 11, 18, 0.78);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
+}
+
+.nav-user-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nav-user-avatar {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(60, 186, 146, 0.35), rgba(60, 186, 146, 0.55));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text);
+  letter-spacing: 0.03em;
+}
+
+.nav-user-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.nav-user-caret {
+  width: 0.75rem;
+  height: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-user-caret::before {
+  content: '';
+  border: 0.32rem solid transparent;
+  border-top-color: var(--muted);
+  transform: translateY(2px);
+  transition: transform 0.2s ease;
+}
+
+.nav-user.is-open .nav-user-caret::before {
+  transform: rotate(180deg) translateY(-1px);
+}
+
+.nav-user-dropdown {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  right: 0;
+  width: min(240px, 85vw);
+  background: rgba(16, 19, 26, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  z-index: 30;
+}
+
+.nav-user-dropdown[hidden] {
+  display: none;
+}
+
+.nav-user-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.nav-user-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.nav-user-role {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.nav-user-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.nav-user-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.nav-user-menu-button {
+  width: 100%;
+  justify-content: flex-start;
+  padding: 0.55rem 0.8rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.06);
+  transition: background 0.15s ease, color 0.15s ease;
+  font-size: 0.95rem;
+  transform: none;
+  text-align: left;
+}
+
+.nav-user-menu-button:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.nav-user-menu-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nav-user-register {
+  background: rgba(240, 180, 41, 0.2);
+  color: var(--text);
+}
+
+.nav-user-register:hover {
+  background: rgba(240, 180, 41, 0.3);
+}
+
+.nav-user-logout {
+  background: rgba(217, 83, 79, 0.18);
+}
+
+.nav-user-logout:hover {
+  background: rgba(217, 83, 79, 0.28);
+}
+
+.nav-user-logout-form {
+  margin: 0;
+}
+
+.nav-user-dropdown form {
+  width: 100%;
 }
 
 .content-area {
@@ -238,6 +406,58 @@ button:disabled {
   gap: 0.5rem;
 }
 
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 11, 18, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 100;
+}
+
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.modal-dialog {
+  width: min(100%, 480px);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-card {
+  position: relative;
+  padding-top: 2.75rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transform: none;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
 .help-text {
   color: var(--muted);
   font-size: 0.9rem;
@@ -306,9 +526,26 @@ button:disabled {
 }
 
 @media (max-width: 600px) {
-  .nav-user {
+  .site-header {
     flex-direction: column;
-    align-items: flex-end;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .nav-user,
+  .nav-actions {
+    width: 100%;
+  }
+
+  .nav-user-toggle {
+    width: 100%;
+    justify-content: space-between;
+    padding-right: 0.6rem;
+  }
+
+  .nav-user-dropdown {
+    width: min(100%, 320px);
+    right: 0;
   }
 
   .inline-form {


### PR DESCRIPTION
## Summary
- replace the user nav link with a styled dropdown that shows the player role and contains the logout action
- add a reusable guest registration modal and hook it to the new dropdown plus an in-game call-to-action for guests
- extend the client script and styles to power the dropdown, modal interactions, and responsive layout tweaks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8fc995a08332ba520de45d625072