### PR TITLE
Adjust header nav placement and refine light theme styles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,17 +1,13 @@
 :root {
-
   font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   color-scheme: dark;
-  color-scheme: light dark;
   --bg: #10131a;
   --bg-alt: #161b24;
+  --body-gradient: radial-gradient(circle at top, rgba(240, 180, 41, 0.08), transparent 55%), var(--bg);
   --accent: #f0b429;
   --accent-dark: #c78c1b;
   --text: #f5f6f8;
   --muted: #a0acc0;
-  --bg: #10131a;
-  --bg-alt: #161b24;
-  --body-gradient: radial-gradient(circle at top, rgba(240, 180, 41, 0.08), transparent 55%), var(--bg);
   --surface: rgba(16, 19, 26, 0.65);
   --surface-strong: rgba(16, 19, 26, 0.75);
   --surface-soft: rgba(8, 11, 18, 0.55);
@@ -38,6 +34,8 @@
   --input-bg-focus: rgba(8, 11, 18, 0.85);
   --input-border: var(--border-strong);
   --nav-divider: rgba(255, 255, 255, 0.12);
+  --error: #d9534f;
+  --success: #3cba92;
 }
 
 :root[data-theme='light'] {
@@ -104,28 +102,18 @@ body {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-  background: radial-gradient(circle at top, rgba(240, 180, 41, 0.08), transparent 55%), var(--bg);
-  color: var(--text);
-  display: flex;
-  flex-direction: column;
-
 }
 
 .site-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-
   gap: clamp(1rem, 2vw, 2rem);
   padding: 1.5rem clamp(1rem, 4vw, 3rem);
   background: var(--header-gradient);
   border-bottom: 1px solid var(--border);
   color: var(--text);
   transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
-
-  padding: 1.5rem clamp(1rem, 4vw, 3rem);
-  background: linear-gradient(135deg, rgba(240, 180, 41, 0.2), rgba(16, 19, 26, 0.8));
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .site-header .brand h1 {
@@ -144,6 +132,7 @@ body {
   align-items: center;
   gap: 0.75rem;
   color: var(--text);
+  margin-left: auto;
 }
 
 .nav-user {
@@ -219,11 +208,6 @@ body {
   border: 1px solid var(--border);
   box-shadow: 0 20px 40px var(--hero-shadow);
   transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
-  background: rgba(16, 19, 26, 0.65);
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
 }
 
 .hero h2 {
@@ -246,11 +230,6 @@ body {
   border: 1px solid var(--border);
   box-shadow: 0 12px 30px var(--card-shadow);
   transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
-  background: rgba(16, 19, 26, 0.75);
-  border-radius: 1rem;
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
 }
 
 .card h3 {
@@ -279,16 +258,6 @@ input:focus {
   outline: 2px solid var(--focus-ring);
   border-color: var(--accent);
   background: var(--input-bg-focus);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  margin-bottom: 0.9rem;
-  background: rgba(8, 11, 18, 0.6);
-  color: var(--text);
-}
-
-input:focus {
-  outline: 2px solid rgba(240, 180, 41, 0.6);
-  border-color: var(--accent);
-  background: rgba(8, 11, 18, 0.85);
 }
 
 .password-strength {
@@ -299,7 +268,6 @@ input:focus {
   height: 0.45rem;
   border-radius: 999px;
   background: var(--border);
-  background: rgba(255, 255, 255, 0.08);
   overflow: hidden;
   margin-bottom: 0.35rem;
 }
@@ -324,7 +292,6 @@ input:focus {
 .password-strength-text {
   font-size: 0.85rem;
   color: var(--muted);
-  color: rgba(255, 255, 255, 0.75);
 }
 
 .password-match {
@@ -332,7 +299,6 @@ input:focus {
   margin: -0.35rem 0 0.85rem;
   min-height: 1.1rem;
   color: var(--muted);
-  color: rgba(255, 255, 255, 0.7);
 }
 
 .password-match.success {
@@ -347,11 +313,7 @@ input:focus {
   font-size: 0.85rem;
   margin: 0.35rem 0 0.85rem;
   min-height: 1.1rem;
-
   color: var(--muted);
-
-  color: rgba(255, 255, 255, 0.7);
-
 }
 
 .availability-message:empty {
@@ -380,9 +342,6 @@ button {
   background: var(--button-bg);
   color: var(--text);
   transition: transform 0.15s ease, background-color 0.15s ease, color 0.15s ease;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text);
-  transition: transform 0.15s ease, background 0.15s ease;
   text-decoration: none;
 }
 
@@ -390,7 +349,6 @@ button {
 button:hover {
   transform: translateY(-1px);
   background: var(--button-bg-hover);
-  background: rgba(255, 255, 255, 0.15);
 }
 
 .button.primary {
@@ -404,7 +362,6 @@ button:hover {
 
 .button.secondary {
   background: var(--button-secondary-bg);
-  background: rgba(60, 186, 146, 0.25);
   color: var(--text);
 }
 
@@ -449,8 +406,6 @@ button:disabled {
   background: var(--surface-soft);
   border: 1px solid var(--border-subtle);
   transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
-  background: rgba(8, 11, 18, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .skill-value {
@@ -459,8 +414,6 @@ button:disabled {
   border-radius: 999px;
   background: var(--skill-chip-bg);
   color: var(--skill-chip-text);
-  background: rgba(240, 180, 41, 0.25);
-  color: var(--accent);
   font-size: 0.85rem;
   margin-left: 0.75rem;
 }
@@ -478,21 +431,14 @@ button:disabled {
 }
 
 .flash-success {
-
   background: var(--flash-success-surface);
   border-color: var(--flash-success-border);
-
-  background: rgba(60, 186, 146, 0.15);
-  border-color: rgba(60, 186, 146, 0.4);
-
   color: var(--text);
 }
 
 .flash-error {
   background: var(--flash-error-surface);
   border-color: var(--flash-error-border);
-  background: rgba(217, 83, 79, 0.15);
-  border-color: rgba(217, 83, 79, 0.45);
   color: var(--text);
 }
 
@@ -516,9 +462,6 @@ button:disabled {
     width: 100%;
     justify-content: space-between;
   }
-
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(8, 11, 18, 0.8);
 }
 
 @media (max-width: 600px) {

--- a/src/templates.js
+++ b/src/templates.js
@@ -418,7 +418,6 @@ function layout({ title, body, user, flash }) {
 
   return `<!DOCTYPE html>
 <html lang="et" data-theme="dark">
-<html lang="et">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -436,7 +435,6 @@ function layout({ title, body, user, flash }) {
       ${themeToggle}
       ${navLinks}
     </div>
-    ${navLinks}
   </header>
   <main class="content-area">
     ${renderFlash(flash)}


### PR DESCRIPTION
## Summary
- keep the header navigation content inside the right-aligned nav container so the duplicate user section disappears
- rely on theme variables for cards, inputs, and alerts so the light theme shows bright surfaces instead of dark fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceae56eb9c833283e5a81575803535