### PR TITLE
Adjust game content layout for future sidebar

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -408,9 +408,13 @@ body:not(.js-enabled) .nav-user-divider {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  justify-content: flex-start;
+  justify-content: center;
   gap: clamp(2rem, 5vw, 3.5rem);
   padding: clamp(1rem, 4vw, 3rem);
+}
+
+.page-layout--sidebar-ready {
+  justify-content: flex-start;
 }
 
 .content-area {

--- a/public/styles.css
+++ b/public/styles.css
@@ -403,14 +403,26 @@ body:not(.js-enabled) .nav-user-divider {
   display: block;
 }
 
-.content-area {
+.page-layout {
   flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: clamp(2rem, 5vw, 3.5rem);
   padding: clamp(1rem, 4vw, 3rem);
+}
+
+.content-area {
+  flex: 0 1 860px;
   display: grid;
   gap: 1.5rem;
-  max-width: 1100px;
+  max-width: 860px;
   width: 100%;
-  margin: 0 auto;
+}
+
+.content-area > * {
+  width: 100%;
 }
 
 .hero {

--- a/src/templates.js
+++ b/src/templates.js
@@ -38,7 +38,7 @@ function renderNavLinks(user) {
     ? '<button type="button" class="nav-user-menu-button nav-user-register" data-open-register>Registreeru</button>'
     : '';
   const registerFallbackLink = user.isGuest
-    ? '<a class="nav-user-menu-button nav-user-register nav-user-register-fallback" href="#guest-register">Registreeru (vorm allpool)</a>'
+    ? '<a class="nav-user-menu-button nav-user-register nav-user-register-fallback" href="/">Registreeru avalehel</a>'
     : '';
   const dropdownId = 'nav-user-menu';
 
@@ -845,10 +845,12 @@ function layout({ title, body, user, flash }) {
       ${navLinks}
     </div>
   </header>
-  <main class="content-area">
-    ${renderFlash(flash)}
-    ${body}
-  </main>
+  <div class="page-layout">
+    <main class="content-area">
+      ${renderFlash(flash)}
+      ${body}
+    </main>
+  </div>
   <footer class="site-footer">
     <p>&copy; ${new Date().getFullYear()} LegendIdle meeskond. See on varajane prototüüp, mis on loodud ideede testimiseks.</p>
   </footer>
@@ -983,69 +985,7 @@ function renderGame({ user, flash }) {
   }).join('');
 
   const guestMessage = user.isGuest
-    ? '<p class="help-text">Säilita külalisena kogutud progress, kasutades allolevat vormi või ava profiilimenüüst valik "Registreeru".</p>'
-    : '';
-
-  const guestRegisterPrompt = user.isGuest
-    ? `<section class="card guest-register-cta" id="guest-register">
-        <h3>Muuda oma külaliskonto püsivaks</h3>
-        <p class="help-text">Täida vorm, et luua püsiv konto.<span class="guest-register-enhanced-note"> Skriptide korral saad avada ka eraldi registreerimisakna.</span></p>
-        <button type="button" class="button primary guest-register-trigger" data-open-register>Alusta registreerimist</button>
-        <div class="guest-register-inline">
-          <form method="POST" action="/register" data-password-form>
-            <label for="guest-register-username">Kasutajanimi</label>
-            <input
-              id="guest-register-username"
-              name="username"
-              required
-              minlength="3"
-              maxlength="12"
-              pattern="(?=.*[A-Za-zÀ-ÖØ-öø-ÿĀ-ž])[A-Za-zÀ-ÖØ-öø-ÿĀ-ž0-9 _]{3,12}"
-              title="Kasutajanimi peab olema 3-12 märki, sisaldama vähemalt ühte tähte ning võib koosneda vaid tähtedest, numbritest, tühikutest ja alakriipsudest."
-              autocomplete="username"
-            />
-            <p class="availability-message" data-availability-username aria-live="polite"></p>
-            <label for="guest-register-email">E-posti aadress</label>
-            <input
-              id="guest-register-email"
-              name="email"
-              type="email"
-              required
-              maxlength="255"
-              autocomplete="email"
-            />
-            <p class="availability-message" data-availability-email aria-live="polite"></p>
-            <label for="guest-register-password">Parool</label>
-            <input
-              id="guest-register-password"
-              name="password"
-              type="password"
-              required
-              minlength="8"
-              autocomplete="new-password"
-              data-password-input
-            />
-            <div class="password-strength" data-password-strength>
-              <div class="password-strength-bar">
-                <span class="password-strength-fill" data-level="weak"></span>
-              </div>
-              <span class="password-strength-text">Sisesta parool, et näha tugevust</span>
-            </div>
-            <label for="guest-register-confirm">Kinnita parool</label>
-            <input
-              id="guest-register-confirm"
-              name="confirmPassword"
-              type="password"
-              required
-              minlength="8"
-              autocomplete="new-password"
-              data-password-confirm
-            />
-            <p class="password-match" data-password-match aria-live="polite"></p>
-            <button type="submit" class="button primary">Loo konto ja salvesta progress</button>
-          </form>
-        </div>
-      </section>`
+    ? '<p class="help-text">Säilita külalisena kogutud progress, avades profiilimenüüst valiku "Registreeru".</p>'
     : '';
 
   const body = `<section class="card">
@@ -1059,8 +999,7 @@ function renderGame({ user, flash }) {
         ${skillList}
       </ul>
       <p class="help-text">Iga treening tõstab vastava oskuse taset ühe võrra. Tulevikus lisanduvad ressursid, varustus ja võitlus.</p>
-    </section>
-    ${guestRegisterPrompt}`;
+    </section>`;
 
   return layout({ title: 'LegendIdle - Mäng', body, user, flash });
 }

--- a/src/templates.js
+++ b/src/templates.js
@@ -133,7 +133,7 @@ function renderGuestRegisterModal() {
   </div>`;
 }
 
-function layout({ title, body, user, flash }) {
+function layout({ title, body, user, flash, pageLayoutModifier }) {
   const navLinks = renderNavLinks(user);
   const guestRegisterModal = user && user.isGuest ? renderGuestRegisterModal() : '';
 
@@ -825,6 +825,11 @@ function layout({ title, body, user, flash }) {
     })();
   </script>`;
 
+  const layoutClasses = ['page-layout'];
+  if (pageLayoutModifier) {
+    layoutClasses.push(pageLayoutModifier);
+  }
+
   return `<!DOCTYPE html>
 <html lang="et" data-theme="dark">
 <head>
@@ -845,7 +850,7 @@ function layout({ title, body, user, flash }) {
       ${navLinks}
     </div>
   </header>
-  <div class="page-layout">
+  <div class="${layoutClasses.join(' ')}">
     <main class="content-area">
       ${renderFlash(flash)}
       ${body}
@@ -1001,7 +1006,13 @@ function renderGame({ user, flash }) {
       <p class="help-text">Iga treening tõstab vastava oskuse taset ühe võrra. Tulevikus lisanduvad ressursid, varustus ja võitlus.</p>
     </section>`;
 
-  return layout({ title: 'LegendIdle - Mäng', body, user, flash });
+  return layout({
+    title: 'LegendIdle - Mäng',
+    body,
+    user,
+    flash,
+    pageLayoutModifier: 'page-layout--sidebar-ready',
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- reposition the main content by wrapping it in a flex layout so that it anchors on the left and leaves space for a future sidebar
- remove the guest register card from the game view and update guest-facing messaging/navigation to point players to existing registration flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cec3653df08332b833ee1c0b7dbe4d