### PR TITLE
Add equipment and tool sidebar to game view

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -716,6 +716,89 @@ body.js-enabled .guest-register-enhanced-note {
   margin-left: 0.75rem;
 }
 
+.game-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.game-main,
+.game-sidebar {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.equipment-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.equipment-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.equipment-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.equipment-slot {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px dashed var(--border-strong);
+  background: var(--surface-soft);
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.equipment-slot:hover {
+  border-color: var(--accent);
+  background: var(--surface-muted);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px var(--card-shadow);
+}
+
+.equipment-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  background: var(--surface-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.equipment-icon svg {
+  width: 2.2rem;
+  height: 2.2rem;
+}
+
+.equipment-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.equipment-label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.equipment-empty {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 .flash {
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
@@ -748,6 +831,16 @@ body.js-enabled .guest-register-enhanced-note {
   border-top: 1px solid var(--border);
   background: var(--footer-bg);
   transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+@media (max-width: 960px) {
+  .game-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .game-sidebar {
+    order: 2;
+  }
 }
 
 @media (max-width: 600px) {

--- a/src/templates.js
+++ b/src/templates.js
@@ -133,6 +133,71 @@ function renderGuestRegisterModal() {
   </div>`;
 }
 
+function renderEquipmentIcon(name) {
+  switch (name) {
+    case 'helmet':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 26a12 12 0 0 1 24 0v10H12Z"></path>
+        <path d="M12 30h24"></path>
+        <path d="M24 16v8"></path>
+      </svg>`;
+    case 'armor':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16 10h16l6 6-5 6v14H15V22l-5-6Z"></path>
+        <path d="M24 10v26"></path>
+        <path d="M16 22h16"></path>
+      </svg>`;
+    case 'gloves':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 12h8l4 6v8l-3 10H17l-3-10v-6Z"></path>
+        <path d="M18 20h12"></path>
+        <path d="M22 12v8"></path>
+      </svg>`;
+    case 'boots':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16 12v12H12v10h24V24h-8V12"></path>
+        <path d="M12 28h24"></path>
+      </svg>`;
+    case 'sword':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M24 6v24"></path>
+        <path d="M18 22h12"></path>
+        <path d="M21 30h6v6l-3 6-3-6Z"></path>
+      </svg>`;
+    case 'shield':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M24 6 38 12v12c0 8-5.5 14-14 18-8.5-4-14-10-14-18V12Z"></path>
+        <path d="M24 12v22"></path>
+      </svg>`;
+    case 'axe':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 10 34 26"></path>
+        <line x1="14" y1="30" x2="22" y2="38"></line>
+        <path d="M30 8h10l-2 10h-8l-4-4Z"></path>
+      </svg>`;
+    case 'pickaxe':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 16c4-6 8-8 12-8s8 2 12 8"></path>
+        <path d="M12 16h24"></path>
+        <path d="M24 16v22"></path>
+      </svg>`;
+    case 'fishing':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16 10c14 8 14 18 12 30"></path>
+        <path d="M16 10 14 22"></path>
+        <path d="M30 34c3 0 4 2 4 4s-1 4-4 4"></path>
+      </svg>`;
+    case 'shovel':
+      return `<svg viewBox="0 0 48 48" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M24 6v22"></path>
+        <path d="M20 6h8l-2 6h-4Z"></path>
+        <path d="M18 30h12v6l-6 6-6-6Z"></path>
+      </svg>`;
+    default:
+      return '';
+  }
+}
+
 function layout({ title, body, user, flash }) {
   const navLinks = renderNavLinks(user);
   const guestRegisterModal = user && user.isGuest ? renderGuestRegisterModal() : '';
@@ -1048,19 +1113,87 @@ function renderGame({ user, flash }) {
       </section>`
     : '';
 
-  const body = `<section class="card">
-      <h2>Tere tulemast tagasi, ${escapeHtml(user.username)}${user.isGuest ? ' (külaline)' : ''}!</h2>
-      <p>See on mängu prototüübi peavaade. Siin saad treenida oma oskusi, vaadata statistikat ning tulevikus ka võidelda teiste mängijatega.</p>
-      ${guestMessage}
-    </section>
-    <section class="card">
-      <h3>Oskused</h3>
-      <ul class="skill-list">
-        ${skillList}
-      </ul>
-      <p class="help-text">Iga treening tõstab vastava oskuse taset ühe võrra. Tulevikus lisanduvad ressursid, varustus ja võitlus.</p>
-    </section>
-    ${guestRegisterPrompt}`;
+  const equipmentSlots = [
+    { key: 'head', label: 'Peakatte', description: 'Ühtegi eset pole varustatud', icon: renderEquipmentIcon('helmet') },
+    { key: 'armor', label: 'Rüü ja püksid', description: 'Ühtegi eset pole varustatud', icon: renderEquipmentIcon('armor') },
+    { key: 'gloves', label: 'Kindad', description: 'Ühtegi eset pole varustatud', icon: renderEquipmentIcon('gloves') },
+    { key: 'boots', label: 'Jalanõud', description: 'Ühtegi eset pole varustatud', icon: renderEquipmentIcon('boots') },
+    { key: 'sword', label: 'Mõõk', description: 'Ühtegi eset pole varustatud', icon: renderEquipmentIcon('sword') },
+    { key: 'shield', label: 'Kilp', description: 'Ühtegi eset pole varustatud', icon: renderEquipmentIcon('shield') },
+  ];
+
+  const equipmentGrid = equipmentSlots
+    .map(
+      ({ key, label, description, icon }) => `
+        <div class="equipment-slot" data-slot="${escapeHtml(key)}">
+          <div class="equipment-icon" aria-hidden="true">
+            ${icon}
+          </div>
+          <div class="equipment-details">
+            <span class="equipment-label">${escapeHtml(label)}</span>
+            <span class="equipment-empty">${escapeHtml(description)}</span>
+          </div>
+        </div>
+      `
+    )
+    .join('');
+
+  const toolSlots = [
+    { key: 'axe', label: 'Kirves', description: 'Ühtegi tööriista pole varustatud', icon: renderEquipmentIcon('axe') },
+    { key: 'pickaxe', label: 'Kirka', description: 'Ühtegi tööriista pole varustatud', icon: renderEquipmentIcon('pickaxe') },
+    { key: 'fishing', label: 'Kalaõng', description: 'Ühtegi tööriista pole varustatud', icon: renderEquipmentIcon('fishing') },
+    { key: 'shovel', label: 'Labidas', description: 'Ühtegi tööriista pole varustatud', icon: renderEquipmentIcon('shovel') },
+  ];
+
+  const toolsGrid = toolSlots
+    .map(
+      ({ key, label, description, icon }) => `
+        <div class="equipment-slot" data-slot="${escapeHtml(key)}">
+          <div class="equipment-icon" aria-hidden="true">
+            ${icon}
+          </div>
+          <div class="equipment-details">
+            <span class="equipment-label">${escapeHtml(label)}</span>
+            <span class="equipment-empty">${escapeHtml(description)}</span>
+          </div>
+        </div>
+      `
+    )
+    .join('');
+
+  const body = `<div class="game-layout">
+      <div class="game-main">
+        <section class="card">
+          <h2>Tere tulemast tagasi, ${escapeHtml(user.username)}${user.isGuest ? ' (külaline)' : ''}!</h2>
+          <p>See on mängu prototüübi peavaade. Siin saad treenida oma oskusi, vaadata statistikat ning tulevikus ka võidelda teiste mängijatega.</p>
+          ${guestMessage}
+        </section>
+        <section class="card">
+          <h3>Oskused</h3>
+          <ul class="skill-list">
+            ${skillList}
+          </ul>
+          <p class="help-text">Iga treening tõstab vastava oskuse taset ühe võrra. Tulevikus lisanduvad ressursid, varustus ja võitlus.</p>
+        </section>
+        ${guestRegisterPrompt}
+      </div>
+      <aside class="game-sidebar">
+        <section class="card equipment-card">
+          <h3>Varustus</h3>
+          <p class="equipment-subtitle">Varusta oma tegelast ja tugevda tema kaitset ning ründeid.</p>
+          <div class="equipment-grid">
+            ${equipmentGrid}
+          </div>
+        </section>
+        <section class="card equipment-card">
+          <h3>Tööriistad</h3>
+          <p class="equipment-subtitle">Vali tööriistad, mis aitavad oskusi treenida.</p>
+          <div class="equipment-grid">
+            ${toolsGrid}
+          </div>
+        </section>
+      </aside>
+    </div>`;
 
   return layout({ title: 'LegendIdle - Mäng', body, user, flash });
 }


### PR DESCRIPTION
## Summary
- add a sidebar to the game view with equipment and tool slots plus placeholder SVG icons
- style the new layout so equipment cards sit to the right of the main content and stay responsive

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cecf1ad91c8332b7a20d36e381df91